### PR TITLE
Fix duplicate split assignment

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
@@ -43,6 +43,10 @@ public class NodeSchedulerConfig
         NODE, STAGE
     }
 
+    public enum CacheAffinityPolicy {
+        NONE, HARD, SOFT
+    }
+
     private int minCandidates = 10;
     private boolean includeCoordinator = true;
     private int maxSplitsPerNode = 100;
@@ -54,6 +58,7 @@ public class NodeSchedulerConfig
     private int maxUnacknowledgedSplitsPerTask = 2000;
     private Duration allowedNoMatchingNodePeriod = new Duration(2, TimeUnit.MINUTES);
     private NodeAllocatorType nodeAllocatorType = NodeAllocatorType.BIN_PACKING;
+    private CacheAffinityPolicy cacheAffinityPolicy = CacheAffinityPolicy.NONE;
 
     @NotNull
     public NodeSchedulerPolicy getNodeSchedulerPolicy()
@@ -228,5 +233,17 @@ public class NodeSchedulerConfig
                 return NodeAllocatorType.BIN_PACKING;
         }
         throw new IllegalArgumentException("Unknown node allocator type: " + nodeAllocatorType);
+    }
+
+    public CacheAffinityPolicy getCacheAffinityPolicy()
+    {
+        return cacheAffinityPolicy;
+    }
+
+    @Config("node-scheduler.cache-affinity-policy")
+    public NodeSchedulerConfig setCacheAffinityPolicy(CacheAffinityPolicy cacheAffinityPolicy)
+    {
+        this.cacheAffinityPolicy = cacheAffinityPolicy;
+        return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SimpleNodeProvider.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SimpleNodeProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import io.trino.metadata.InternalNode;
+import io.trino.spi.HostAddress;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+public class SimpleNodeProvider
+{
+    private final List<InternalNode> sortedNodes;
+
+    public SimpleNodeProvider(List<InternalNode> sortedNodes)
+    {
+        this.sortedNodes = sortedNodes;
+    }
+
+    public List<HostAddress> get(String identifier, int count)
+    {
+        int size = sortedNodes.size();
+        int mod = identifier.hashCode() % size;
+        int position = mod < 0 ? mod + size : mod;
+        List<HostAddress> chosenCandidates = new ArrayList<>();
+        if (count > size) {
+            count = size;
+        }
+        for (int i = 0; i < count && i < sortedNodes.size(); i++) {
+            chosenCandidates.add(sortedNodes.get((position + i) % size).getHostAndPort());
+        }
+        return unmodifiableList(chosenCandidates);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
@@ -67,6 +67,7 @@ public class UniformNodeSelectorFactory
     private final boolean optimizedLocalScheduling;
     private final NodeTaskMap nodeTaskMap;
     private final Duration nodeMapMemoizationDuration;
+    private final NodeSchedulerConfig.CacheAffinityPolicy cacheAffinityPolicy;
 
     @Inject
     public UniformNodeSelectorFactory(
@@ -99,6 +100,7 @@ public class UniformNodeSelectorFactory
         this.minPendingSplitsWeightPerTask = SplitWeight.rawValueForStandardSplitCount(minPendingSplitsPerTask);
         this.maxAdjustedPendingSplitsWeightPerTask = SplitWeight.rawValueForStandardSplitCount(maxAdjustedPendingSplitsWeightPerTask);
         this.nodeMapMemoizationDuration = nodeMapMemoizationDuration;
+        this.cacheAffinityPolicy = config.getCacheAffinityPolicy();
     }
 
     @Override
@@ -129,7 +131,8 @@ public class UniformNodeSelectorFactory
                 maxAdjustedPendingSplitsWeightPerTask,
                 getMaxUnacknowledgedSplitsPerTask(session),
                 splitsBalancingPolicy,
-                optimizedLocalScheduling);
+                optimizedLocalScheduling,
+                cacheAffinityPolicy);
     }
 
     private NodeMap createNodeMap(Optional<CatalogHandle> catalogHandle)

--- a/core/trino-main/src/main/java/io/trino/metadata/Split.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Split.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -88,5 +89,10 @@ public final class Split
         return INSTANCE_SIZE
                 + catalogHandle.getRetainedSizeInBytes()
                 + connectorSplit.getRetainedSizeInBytes();
+    }
+
+    public Optional<String> getCacheIdentifier()
+    {
+        return connectorSplit.getCacheIdentifier();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.execution.scheduler.NodeSchedulerConfig.CacheAffinityPolicy.NONE;
+import static io.trino.execution.scheduler.NodeSchedulerConfig.CacheAffinityPolicy.SOFT;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.NodeSchedulerPolicy.UNIFORM;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy.NODE;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -43,7 +45,8 @@ public class TestNodeSchedulerConfig
                 .setSplitsBalancingPolicy(NodeSchedulerConfig.SplitsBalancingPolicy.STAGE)
                 .setOptimizedLocalScheduling(true)
                 .setAllowedNoMatchingNodePeriod(new Duration(2, MINUTES))
-                .setNodeAllocatorType("bin_packing"));
+                .setNodeAllocatorType("bin_packing")
+                .setCacheAffinityPolicy(NONE));
     }
 
     @Test
@@ -61,6 +64,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.optimized-local-scheduling", "false")
                 .put("node-scheduler.allowed-no-matching-node-period", "1m")
                 .put("node-scheduler.allocator-type", "fixed_count")
+                .put("node-scheduler.cache-affinity-policy", "SOFT")
                 .buildOrThrow();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -74,7 +78,8 @@ public class TestNodeSchedulerConfig
                 .setSplitsBalancingPolicy(NODE)
                 .setOptimizedLocalScheduling(false)
                 .setAllowedNoMatchingNodePeriod(new Duration(1, MINUTES))
-                .setNodeAllocatorType("fixed_count");
+                .setNodeAllocatorType("fixed_count")
+                .setCacheAffinityPolicy(SOFT);
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.execution.scheduler.NodeSchedulerConfig.CacheAffinityPolicy.NONE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
@@ -134,6 +135,7 @@ public class TestUniformNodeSelector
                 500,
                 NodeSchedulerConfig.SplitsBalancingPolicy.STAGE,
                 false,
+                NONE,
                 queueSizeAdjuster);
 
         Set<Split> splits = new LinkedHashSet<>();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
@@ -17,6 +17,7 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConnectorSplit
 {
@@ -41,5 +42,10 @@ public interface ConnectorSplit
     default long getRetainedSizeInBytes()
     {
         throw new UnsupportedOperationException("This connector does not provide memory accounting capabilities for ConnectorSplit");
+    }
+
+    default Optional<String> getCacheIdentifier()
+    {
+        return Optional.empty();
     }
 }

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -99,6 +99,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-shaded-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.gaul</groupId>
             <artifactId>modernizer-maven-annotations</artifactId>
         </dependency>

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingFileSystemFactory.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingFileSystemFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.hdfs;
+
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.spi.security.ConnectorIdentity;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class CachingFileSystemFactory
+        implements TrinoFileSystemFactory
+{
+    private final HdfsEnvironment environment;
+    private final CacheManager cacheManager;
+    private final AlluxioConfiguration alluxioConf;
+
+    @Inject
+    public CachingFileSystemFactory(HdfsEnvironment environment,
+            CacheManager cacheManager, AlluxioConfiguration alluxioConf)
+    {
+        this.environment = requireNonNull(environment, "environment is null");
+        this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
+        this.alluxioConf = requireNonNull(alluxioConf, "alluxioConf is null");
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity)
+    {
+        return new CachingHdfsFileSystem(environment, new HdfsContext(identity), cacheManager, alluxioConf);
+    }
+}

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsFileSystem.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.hdfs;
+
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+
+public class CachingHdfsFileSystem
+        extends HdfsFileSystem
+{
+    private final CacheManager cacheManager;
+    private final AlluxioConfiguration alluxioConf;
+
+    public CachingHdfsFileSystem(HdfsEnvironment environment, HdfsContext context, CacheManager cacheManager, AlluxioConfiguration alluxioConf)
+    {
+        super(environment, context);
+        this.cacheManager = cacheManager;
+        this.alluxioConf = alluxioConf;
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(String path)
+    {
+        return new CachingHdfsInputFile(path, null, environment, context, cacheManager, alluxioConf);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(String path, long length)
+    {
+        return new CachingHdfsInputFile(path, length, environment, context, cacheManager, alluxioConf);
+    }
+}

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsInputFile.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsInputFile.java
@@ -59,7 +59,7 @@ public class CachingHdfsInputFile
                     .setPath(file.toString())
                     .setFolder(false)
                     .setLength(lazyStatus().getLen());
-            String cacheIdentifier = md5().hashString(file.toString(), UTF_8).toString();
+            String cacheIdentifier = md5().hashString(file.toString() + lazyStatus().getModificationTime(), UTF_8).toString();
             URIStatus uriStatus = new URIStatus(info, CacheContext.defaults().setCacheIdentifier(cacheIdentifier));
             return new FSDataInputStream(new HdfsFileInputStream(
                     new LocalCacheFileInStream(uriStatus, (uri) -> new AlluxioHdfsInputStream(fileSystem.open(file)), cacheManager, alluxioConf),

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsInputFile.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/CachingHdfsInputFile.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.hdfs;
+
+import alluxio.client.file.CacheContext;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.LocalCacheFileInStream;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.hadoop.AlluxioHdfsInputStream;
+import alluxio.hadoop.HdfsFileInputStream;
+import alluxio.wire.FileInfo;
+import io.trino.filesystem.TrinoInput;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+
+import static com.google.common.hash.Hashing.md5;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class CachingHdfsInputFile
+        extends HdfsInputFile
+{
+    private final CacheManager cacheManager;
+    private final AlluxioConfiguration alluxioConf;
+
+    private final FileSystem.Statistics statistics = new FileSystem.Statistics("alluxio");
+
+    public CachingHdfsInputFile(String path, Long length, HdfsEnvironment environment, HdfsContext context,
+            CacheManager cacheManager, AlluxioConfiguration alluxioConf)
+    {
+        super(path, length, environment, context);
+        this.cacheManager = cacheManager;
+        this.alluxioConf = alluxioConf;
+    }
+
+    @Override
+    public TrinoInput newInput()
+            throws IOException
+    {
+        FileSystem fileSystem = environment.getFileSystem(context, file);
+        FSDataInputStream input = environment.doAs(context.getIdentity(), () -> {
+            FileInfo info = new FileInfo()
+                    .setLastModificationTimeMs(lazyStatus().getModificationTime())
+                    .setPath(file.toString())
+                    .setFolder(false)
+                    .setLength(lazyStatus().getLen());
+            String cacheIdentifier = md5().hashString(file.toString(), UTF_8).toString();
+            URIStatus uriStatus = new URIStatus(info, CacheContext.defaults().setCacheIdentifier(cacheIdentifier));
+            return new FSDataInputStream(new HdfsFileInputStream(
+                    new LocalCacheFileInStream(uriStatus, (uri) -> new AlluxioHdfsInputStream(fileSystem.open(file)), cacheManager, alluxioConf),
+                    statistics));
+        });
+        return new HdfsInput(input, this);
+    }
+}

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
@@ -38,11 +38,11 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
-class HdfsFileSystem
+public class HdfsFileSystem
         implements TrinoFileSystem
 {
-    private final HdfsEnvironment environment;
-    private final HdfsContext context;
+    protected final HdfsEnvironment environment;
+    protected final HdfsContext context;
 
     public HdfsFileSystem(HdfsEnvironment environment, HdfsContext context)
     {

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsInputFile.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsInputFile.java
@@ -34,9 +34,9 @@ class HdfsInputFile
         implements TrinoInputFile
 {
     private final String path;
-    private final HdfsEnvironment environment;
-    private final HdfsContext context;
-    private final Path file;
+    protected final HdfsEnvironment environment;
+    protected final HdfsContext context;
+    protected final Path file;
     private Long length;
     private FileStatus status;
 
@@ -108,7 +108,7 @@ class HdfsInputFile
         return environment.doAs(context.getIdentity(), () -> fileSystem.open(file));
     }
 
-    private FileStatus lazyStatus()
+    protected FileStatus lazyStatus()
             throws IOException
     {
         if (status == null) {

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemConfig.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.hdfs.cache;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+
+import javax.annotation.Nullable;
+
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+
+public class CachingFileSystemConfig
+{
+    private boolean cacheEnabled;
+    private String baseDirectory;
+    private DataSize maxCacheSize = DataSize.of(2, GIGABYTE);
+
+    public boolean isCacheEnabled()
+    {
+        return cacheEnabled;
+    }
+
+    @Config("cache.enabled")
+    @ConfigDescription("Cache data file to workers' local storage")
+    public CachingFileSystemConfig setCacheEnabled(boolean value)
+    {
+        this.cacheEnabled = value;
+        return this;
+    }
+
+    @Nullable
+    public String getBaseDirectory()
+    {
+        return baseDirectory;
+    }
+
+    @Config("cache.base-directory")
+    @ConfigDescription("Base URI to cache data")
+    public CachingFileSystemConfig setBaseDirectory(String baseDirectory)
+    {
+        this.baseDirectory = baseDirectory;
+        return this;
+    }
+
+    public DataSize getMaxCacheSize()
+    {
+        return maxCacheSize;
+    }
+
+    @Config("cache.max-cache-size")
+    @ConfigDescription("The maximum cache size available for cache")
+    public CachingFileSystemConfig setMaxCacheSize(DataSize maxCacheSize)
+    {
+        this.maxCacheSize = maxCacheSize;
+        return this;
+    }
+}

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemModule.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemModule.java
@@ -18,6 +18,8 @@ import alluxio.conf.AlluxioConfiguration;
 import alluxio.conf.AlluxioProperties;
 import alluxio.conf.InstancedConfiguration;
 import alluxio.conf.PropertyKey;
+import alluxio.metrics.MetricsConfig;
+import alluxio.metrics.MetricsSystem;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -27,6 +29,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.CachingFileSystemFactory;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -39,6 +42,10 @@ public class CachingFileSystemModule
     {
         configBinder(binder).bindConfig(CachingFileSystemConfig.class);
         binder.bind(TrinoFileSystemFactory.class).to(CachingFileSystemFactory.class).in(SINGLETON);
+        Properties metricProps = new Properties();
+        metricProps.put("sink.jmx.class", "alluxio.metrics.sink.JmxSink");
+        metricProps.put("sink.jmx.domain", "org.alluxio");
+        MetricsSystem.startSinksFromConfig(new MetricsConfig(metricProps));
     }
 
     @Inject
@@ -52,6 +59,7 @@ public class CachingFileSystemModule
             alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_DIRS, config.getBaseDirectory());
         }
         alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_SIZE, config.getMaxCacheSize().toString());
+        alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_SHADOW_ENABLED, "true");
         return new InstancedConfiguration(alluxioProperties);
     }
 

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemModule.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/cache/CachingFileSystemModule.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.hdfs.cache;
+
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.conf.PropertyKey;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.hdfs.CachingFileSystemFactory;
+
+import java.io.IOException;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class CachingFileSystemModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(CachingFileSystemConfig.class);
+        binder.bind(TrinoFileSystemFactory.class).to(CachingFileSystemFactory.class).in(SINGLETON);
+    }
+
+    @Inject
+    @Provides
+    @Singleton
+    public AlluxioConfiguration getAlluxioConfiguration(CachingFileSystemConfig config)
+    {
+        AlluxioProperties alluxioProperties = new AlluxioProperties();
+        alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_ENABLED, config.isCacheEnabled());
+        if (config.getBaseDirectory() != null) {
+            alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_DIRS, config.getBaseDirectory());
+        }
+        alluxioProperties.set(PropertyKey.USER_CLIENT_CACHE_SIZE, config.getMaxCacheSize().toString());
+        return new InstancedConfiguration(alluxioProperties);
+    }
+
+    @Inject
+    @Provides
+    @Singleton
+    public CacheManager getCacheManager(AlluxioConfiguration alluxioConfiguration)
+    {
+        try {
+            return CacheManager.Factory.get(alluxioConfiguration);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -20,8 +20,6 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
-import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hdfs.TrinoFileSystemCache;
 import io.trino.hdfs.TrinoFileSystemCacheStats;
 import io.trino.plugin.base.CatalogName;
@@ -127,7 +125,6 @@ public class HiveModule
                 .as(generator -> generator.generatedNameOf(io.trino.plugin.hive.fs.TrinoFileSystemCache.class));
 
         configBinder(binder).bindConfig(HiveFormatsConfig.class);
-        binder.bind(TrinoFileSystemFactory.class).to(HdfsFileSystemFactory.class).in(Scopes.SINGLETON);
 
         Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(CsvPageSourceFactory.class).in(Scopes.SINGLETON);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -310,6 +310,12 @@ public class HiveSplit
     }
 
     @Override
+    public Optional<String> getCacheIdentifier()
+    {
+        return Optional.of(path);
+    }
+
+    @Override
     public String toString()
     {
         return toStringHelper(this)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -24,6 +24,8 @@ import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.event.client.EventModule;
 import io.airlift.json.JsonModule;
 import io.trino.filesystem.hdfs.HdfsFileSystemModule;
+import io.trino.filesystem.hdfs.cache.CachingFileSystemConfig;
+import io.trino.filesystem.hdfs.cache.CachingFileSystemModule;
 import io.trino.hdfs.HdfsModule;
 import io.trino.hdfs.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.base.CatalogName;
@@ -119,7 +121,8 @@ public final class InternalHiveConnectorFactory
                     new HiveMetastoreModule(metastore),
                     new HiveSecurityModule(),
                     new HdfsAuthenticationModule(),
-                    new HdfsFileSystemModule(),
+                    conditionalModule(CachingFileSystemConfig.class, CachingFileSystemConfig::isCacheEnabled,
+                            new CachingFileSystemModule(), new HdfsFileSystemModule()),
                     new HiveProcedureModule(),
                     new MBeanServerModule(),
                     binder -> {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -247,6 +247,10 @@ public final class HiveQueryRunner
                 hiveProperties.put("hive.max-partitions-per-scan", "1000");
                 hiveProperties.put("hive.max-partitions-for-eager-load", "1000");
                 hiveProperties.put("hive.security", security);
+
+                hiveProperties.put("cache.enabled", "true");
+                hiveProperties.put("cache.base-directory", "/tmp/cache");
+
                 hiveProperties.putAll(this.hiveProperties.buildOrThrow());
 
                 if (tpchBucketedCatalogEnabled) {

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -298,4 +298,19 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns combine.children="append">
+                        <!-- com.google.protobuf:protobuf-java and com.squareup.wire:wire-schema proto file duplicate -->
+                        <ignoredResourcePattern>google/protobuf/.*\.proto$</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1674,7 +1674,7 @@
             <dependency>
                 <groupId>org.alluxio</groupId>
                 <artifactId>alluxio-shaded-client</artifactId>
-                <version>2.8.1</version>
+                <version>2.9.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### background

When testing Trino + Alluxio Local Cache, I found sometimes
1. tasks were assigned to the coordinator even "node-scheduler.include-coordinator=false"
2. the result had duplicate results 

After some checking, I located the causes.

For "tasks were assigned to the coordinator", the cause is here: https://github.com/beinan/prestosql/blob/3653b347a84788ec16271f9ee01f35107ff0bbc8/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java#L128 , which is expected when `node-scheduler.optimized-local-scheduling=true` and the coordinator is in the same node with a hdfs datanode.

For "the result had duplicate results", the cause is here: https://github.com/beinan/prestosql/blob/3653b347a84788ec16271f9ee01f35107ff0bbc8/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java#L201 . The same split may be assigned under `if (cacheAffinityPolicy != NONE) {` and `if (optimizedLocalScheduling) {` at the same time.

### changes 

1. Fix duplicate split assignment
2. Make local node assignment has higher priority than affinity assignment, as it has close performance and lower cost.